### PR TITLE
Change runtype_options

### DIFF
--- a/runtype_options.json
+++ b/runtype_options.json
@@ -1,53 +1,270 @@
 {
-  "HBIR": [
-    "Kit Version",
-    "Tag",
-    "JDK",
-    "RTSTART",
-    "JVM Options",
-    "NUMA Nodes",
-    "Data Collection",
-    "T1",
-    "T2",
-    "T3"
-  ],
-  "HBIR_RT": [
-    "Kit Version",
-    "Tag",
-    "JDK",
-    "RTSTART",
-    "JVM Options",
-    "NUMA Nodes",
-    "Data Collection",
-    "T1",
-    "T2",
-    "T3"
-  ],
-  "PRESET": [
-    "kitVersion",
-    "tag",
-    "JDK",
-    "TXrate",
-    "Duration",
-    "JVMoptions",
-    "NUMA_Node",
-    "Data Collection",
-    "T1",
-    "T2",
-    "T3"
-  ],
-  "LOADLEVEL": [
-    "Kit Version",
-    "Tag",
-    "JDK",
-    "RTSTART",
-    "JVM Options",
-    "NUMA Nodes",
-    "Data Collection",
-    "T1",
-    "T2",
-    "T3"
-  ]
-}
+  "HBIR": {
+    "args" : [
+      "Tag",
+      "Kit Version",
+      "JDK",
+      "RTSTART",
+      "JVM Options",
+      "NUMA Nodes",
+      "Data Collection",
+      "T1",
+      "T2",
+      "T3"
+    ],
 
+    "annotations" : {
+      "Tag" : "Name of the run",
+      "Kit Version" : "Version of SpecJBB",
+      "JDK" : "Version of the JVM that will run SpecJBB",
+      "RTSTART" : "What percentage of total output will we start at",
+      "JVM Options" : "What additional arguments, if any, will be passed to the JVM",
+      "NUMA Nodes" : "How many NUMA nodes will SpecJBB use",
+      "Data Collection" : "What data collection process will monitor while running SpecJBB",
+      "T1" : "How many threads does Tier 1 have access to",
+      "T2" : "How many threads does Tier 2 have access to",
+      "T3" : "How many threads does Tier 3 have access to"
+    },
+
+    "types" : {
+      "Tag" : "string",
+      "Kit Version" : "string",
+      "JDK" : "string",
+      "RTSTART" : "integer",
+      "JVM Options" : "string",
+      "NUMA Nodes" : "integer",
+      "Data Collection" : "string",
+      "T1" : "integer",
+      "T2" : "integer",
+      "T3" : "integer"
+    },
+
+    "translations" : {
+      "RTSTART" : "specjbb.controller.rtcurve.start",
+      "T1" : "specjbb.forkjoin.workers.Tier1",
+      "T2" : "specjbb.forkjoin.workers.Tier2",
+      "T3" : "specjbb.forkjoin.workers.Tier3",
+      "NUMA Nodes" : "specjbb.group.count"
+    },
+
+    "default_props" : {
+      "specjbb.controller.type" : "HBIR",
+      "specjbb.time.server" : false,
+      "specjbb.comm.connect.client.pool.size" : 192,
+      "specjbb.comm.connect.selector.runner.count" : 4,
+      "specjbb.comm.connect.timeouts.connect" : 650000,
+      "specjbb.comm.connect.timeouts.read" : 650000,
+      "specjbb.comm.connect.timeouts.write" : 650000,
+      "specjbb.comm.connect.worker.pool.max" : 320,
+      "specjbb.customerDriver.threads" : 64,
+      "specjbb.customerDriver.threads.saturate" : 144,
+      "specjbb.customerDriver.threads.probe" : 96,
+      "specjbb.mapreducer.pool.size" : 27
+    }
+  },
+
+  "HBIR_RT": {
+    "args" : [
+      "Tag",
+      "Kit Version",
+      "JDK",
+      "RTSTART",
+      "JVM Options",
+      "NUMA Nodes",
+      "Data Collection",
+      "T1",
+      "T2",
+      "T3"
+    ],
+
+    "annotations" : {
+      "Tag" : "Name of the run",
+      "Kit Version" : "Version of SpecJBB",
+      "JDK" : "Version of the JVM that will run SpecJBB",
+      "RTSTART" : "What percentage of total output will we start at",
+      "JVM Options" : "What additional arguments, if any, will be passed to the JVM",
+      "NUMA Nodes" : "How many NUMA nodes will SpecJBB use",
+      "Data Collection" : "What data collection process will monitor while running SpecJBB",
+      "T1" : "How many threads does Tier 1 have access to",
+      "T2" : "How many threads does Tier 2 have access to",
+      "T3" : "How many threads does Tier 3 have access to"
+    },
+
+    "types" : {
+      "Tag" : "string",
+      "Kit Version" : "string",
+      "JDK" : "string",
+      "RTSTART" : "integer",
+      "JVM Options" : "string",
+      "NUMA Nodes" : "integer",
+      "Data Collection" : "string",
+      "T1" : "integer",
+      "T2" : "integer",
+      "T3" : "integer"
+    },
+
+    "translations" : {
+      "RTSTART" : "specjbb.controller.rtcurve.start",
+      "T1" : "specjbb.forkjoin.workers.Tier1",
+      "T2" : "specjbb.forkjoin.workers.Tier2",
+      "T3" : "specjbb.forkjoin.workers.Tier3",
+      "NUMA Nodes" : "specjbb.group.count"
+    },
+
+    "default_props" : {
+      "specjbb.controller.type" : "HBIR_RT",
+      "specjbb.time.server" : false,
+      "specjbb.comm.connect.client.pool.size" : 192,
+      "specjbb.comm.connect.selector.runner.count" : 4,
+      "specjbb.comm.connect.timeouts.connect" : 650000,
+      "specjbb.comm.connect.timeouts.read" : 650000,
+      "specjbb.comm.connect.timeouts.write" : 650000,
+      "specjbb.comm.connect.worker.pool.max" : 320,
+      "specjbb.customerDriver.threads" : 64,
+      "specjbb.customerDriver.threads.saturate" : 144,
+      "specjbb.customerDriver.threads.probe" : 96,
+      "specjbb.mapreducer.pool.size" : 27
+    }
+  },
+
+  "PRESET": {
+    "args" : [
+      "Tag",
+      "Kit Version",
+      "JDK",
+      "TXrate",
+      "Duration",
+      "JVM Options",
+      "NUMA Nodes",
+      "Data Collection",
+      "T1",
+      "T2",
+      "T3"
+    ],
+
+    "annotations" : {
+      "Tag" : "Name of the run",
+      "Kit Version" : "Version of SpecJBB",
+      "JDK" : "Version of the JVM that will run SpecJBB",
+      "TXrate" : "Rate of transmissions... GET HELP FROM MIKE JONES",
+      "Duration" : "Length of time... GET HELP FROM MIKE JONES",
+      "JVM Options" : "What additional arguments, if any, will be passed to the JVM",
+      "NUMA Nodes" : "How many NUMA nodes will SpecJBB use",
+      "Data Collection" : "What data collection process will monitor while running SpecJBB",
+      "T1" : "How many threads does Tier 1 have access to",
+      "T2" : "How many threads does Tier 2 have access to",
+      "T3" : "How many threads does Tier 3 have access to"
+    },
+
+    "types" : {
+      "Tag" : "string",
+      "Kit Version" : "string",
+      "JDK" : "string",
+      "TXrate" : "integer",
+      "JVM Options" : "string",
+      "NUMA Nodes" : "integer",
+      "Data Collection" : "string",
+      "T1" : "integer",
+      "T2" : "integer",
+      "T3" : "integer"
+    },
+
+    "translations" : {
+      "TXrate" : "specjbb.controller.preset.ir",
+      "Duration" : "specjbb.controller.preset.duration",
+      "T1" : "specjbb.forkjoin.workers.Tier1",
+      "T2" : "specjbb.forkjoin.workers.Tier2",
+      "T3" : "specjbb.forkjoin.workers.Tier3",
+      "NUMA Nodes" : "specjbb.group.count"
+    },
+
+    "default_props" : {
+      "specjbb.controller.type" : "PRESET",
+      "specjbb.comm.connect.client.pool.size" : 192,
+      "specjbb.comm.connect.selector.runner.count" : 4,
+      "specjbb.comm.connect.timeouts.connect" : 650000,
+      "specjbb.comm.connect.timeouts.read" : 650000,
+      "specjbb.comm.connect.timeouts.write" : 650000,
+      "specjbb.comm.connect.worker.pool.max" : 320,
+      "specjbb.customerDriver.threads" : 64,
+      "specjbb.customerDriver.threads.saturate" : 144,
+      "specjbb.customerDriver.threads.probe" : 96,
+      "specjbb.mapreducer.pool.size" : 27
+    }
+  },
+
+  "LOADLEVEL": {
+    "args" : [
+      "Tag",
+      "Kit Version",
+      "JDK",
+      "RTSTART",
+      "Duration Min",
+      "Duration Max",
+      "JVM Options",
+      "NUMA Nodes",
+      "Data Collection",
+      "T1",
+      "T2",
+      "T3"
+    ],
+
+    "annotations" : {
+      "Tag" : "Name of the run",
+      "Kit Version" : "Version of SpecJBB",
+      "JDK" : "Version of the JVM that will run SpecJBB",
+      "RTSTART" : "What percentage of total output will we start at",
+      "Duration Min" : "Duration of something... GET HELP FROM MIKE JONES",
+      "Duration Max" : "Duration of something... GET HELP FROM MIKE JONES",
+      "JVM Options" : "What additional arguments, if any, will be passed to the JVM",
+      "NUMA Nodes" : "How many NUMA nodes will SpecJBB use",
+      "Data Collection" : "What data collection process will monitor while running SpecJBB",
+      "T1" : "How many threads does Tier 1 have access to",
+      "T2" : "How many threads does Tier 2 have access to",
+      "T3" : "How many threads does Tier 3 have access to"
+    },
+
+    "types" : {
+      "Tag" : "string",
+      "Kit Version" : "string",
+      "JDK" : "string",
+      "RTSTART" : "integer",
+      "Duration Min" : "integer",
+      "Duration Max" : "integer",
+      "JVM Options" : "string",
+      "NUMA Nodes" : "integer",
+      "Data Collection" : "string",
+      "T1" : "integer",
+      "T2" : "integer",
+      "T3" : "integer"
+    },
+
+    "translations" : {
+      "Duration Min" : "specjbb.controller.loadlevel.duration.min",
+      "Duration Max" : "specjbb.controller.loadlevel.duration.max",
+      "RTSTART" : "specjbb.controller.rtcurve.start",
+      "T1" : "specjbb.forkjoin.workers.Tier1",
+      "T2" : "specjbb.forkjoin.workers.Tier2",
+      "T3" : "specjbb.forkjoin.workers.Tier3",
+      "NUMA Nodes" : "specjbb.group.count"
+    },
+
+    "default_props" : {
+      "specjbb.controller.type" : "HBIR_RT_LOADLEVELS",
+      "specjbb.controller.loadlevel.start" : 0.95,
+      "specjbb.controller.loadlevel.step" : 1 ,
+      "specjbb.time.server" : false,
+      "specjbb.comm.connect.client.pool.size" : 192,
+      "specjbb.comm.connect.selector.runner.count" : 4,
+      "specjbb.comm.connect.timeouts.connect" : 650000,
+      "specjbb.comm.connect.timeouts.read" : 650000,
+      "specjbb.comm.connect.timeouts.write" : 650000,
+      "specjbb.comm.connect.worker.pool.max" : 320,
+      "specjbb.customerDriver.threads" : 64,
+      "specjbb.customerDriver.threads.saturate" : 144,
+      "specjbb.customerDriver.threads.probe" : 96,
+      "specjbb.mapreducer.pool.size" : 27
+    }
+  }
+}
 


### PR DESCRIPTION
This goes with the meeting that we held today.

Each runtype will now contain the following values:

* args, containing an ordered list of arguments. This is for the
purpose of dialogue and presenting each parameter to the user.

* annotations, containing key-value pairs of arguments and
descriptions for each one. This is for explaining each parameter
to the user.

* types, containing key-value pairs of arguments and types. This
is for defining valid user input for each argument.

* translations, containing key-value pairs of arguments and
.props values. Upon running in main, the program will take a Run
and its corresponding RunType and write values to its temporary
.props file.

* props_defaults, containing values that will be written by
default to the .props file without any user input at all.
These are intrinsic to the RunType.

For example, let's say that we have an RunType with the following:

    "SPAM" : {
      args : [
        "foo"
        "bar"
      ],

      annotations : {
        "foo" : "Lorem ipsum dolor sit amet, consectetur...",
        "bar" : "Sed blandit metus quis nulla dapibus..."
      },

      "types" : {
        "foo" : "string",
        "bar" : "integer"
      },

      "translations" : {
        "foo" : "controller.quux.spam.eggs.foo"
      }

      "props_defaults" : {
        "controller.muffin.scone" : false,
        "controller.waffle.pancake" : 50,
        "controller.bacon.sausage" : "eggs"
      }
    }

Upon a user creating a SPAM Run, the Dialogue will ask the user to
provide values for `foo` and `bar`, demanding a string and integer
as input, respectively. If needed, the user can obtain the annotations
(Lorem ipsum dolor sit amet...) to explain what he is supposed to input.
Let's say that he inputs `oatmeal` and `5`, respectively.

Upon running the above run, `main` will write the following to
the temporary .props file:

    controller.quux.spam.eggs.foo=oatmeal
    controller.muffin.scone=false
    controller.waffle.pancake=50
    controller.bacon.sausage=eggs

The remaining `bar` value will possibly be used in the actual JVM
invocation.