### PR TITLE
Target Ubuntu 16.04 and modern python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
 os:


### PR DESCRIPTION
Ubuntu 16.04 only has python version 3.5, and we've been discussing supporting only new python versions. This changes automated builds to only use 3.5 and 3.6, so we don't have to worry about lower versions in future builds.