### PR TITLE
First shot at replacing run.sh

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
+testfixtures = "*"
 
 [packages]
 docopt = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ testfixtures = "*"
 docopt = "*"
 six = "*"
 schema = "*"
+uuid = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f83bf24b726a13a6b7990bd38899fe08a1b3158a7adccbd45c549ae0d775bf5a"
+            "sha256": "081ea833c83722bf0eceba18239e3d5a58dd0f08859e4f7a6631023f6bbb9cf0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -38,6 +38,13 @@
             ],
             "index": "pypi",
             "version": "==1.11.0"
+        },
+        "uuid": {
+            "hashes": [
+                "sha256:1f87cc004ac5120466f36c5beae48b4c48cc411968eed0eaecd3da82aa96193f"
+            ],
+            "index": "pypi",
+            "version": "==1.30"
         }
     },
     "develop": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "78c5a2bc0522cc2d0bea110d2ebd8638b4b0532eb80062ecf93262cd446fcc01"
+            "sha256": "f83bf24b726a13a6b7990bd38899fe08a1b3158a7adccbd45c549ae0d775bf5a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -40,5 +40,14 @@
             "version": "==1.11.0"
         }
     },
-    "develop": {}
+    "develop": {
+        "testfixtures": {
+            "hashes": [
+                "sha256:7e6d52438c9d86e8519cf4073be51b6f47051fc46bdbd3dde9b3228da3d270bb",
+                "sha256:fac59f8444e117636cbfee92a26e461bc5e961cfabf6a631d1f3a0bf40559c90"
+            ],
+            "index": "pypi",
+            "version": "==6.0.1"
+        }
+    }
 }

--- a/mainCLI.py
+++ b/mainCLI.py
@@ -9,7 +9,7 @@ Usage:
     mainCLI.py --version
 
 Options:
-    --level=<log-level>       Set the logging level. [default: INFO]
+    --level=<log-level>       Set the logging level. Uses python.logging's names for the different leves. [default: INFO]
 """
 # library imports
 import json

--- a/mainCLI.py
+++ b/mainCLI.py
@@ -1,16 +1,20 @@
 """SPECtate.
 
 Usage:
-    mainCLI.py run <config> [--props <props>]
-    mainCLI.py validate <config>
-    mainCLI.py dialogue
-    mainCLI.py spectate <config>
+    mainCLI.py run [options] <config> [--props <props>]
+    mainCLI.py validate [options] <config>
+    mainCLI.py dialogue [options]
+    mainCLI.py spectate [options] <config>
     mainCLI.py (-h | --help)
     mainCLI.py --version
+
+Options:
+    --level=<log-level>       Set the logging level. [default: INFO]
 """
 # library imports
 import json
 import os
+import logging
 from subprocess import call
 from shutil import copy, rmtree
 
@@ -125,6 +129,8 @@ do = {
 
 if __name__ == "__main__":
     arguments = docopt(__doc__, version='SPECtate v0.1')
+    print(arguments)
+    logging.basicConfig(level=logging.getLevelName(arguments['--level']))
 
     for key, func in do.items():
         if arguments[key]:

--- a/mainCLI.py
+++ b/mainCLI.py
@@ -4,6 +4,7 @@ Usage:
     mainCLI.py run <config> [--props <props>]
     mainCLI.py validate <config>
     mainCLI.py dialogue
+    mainCLI.py spectate <config>
     mainCLI.py (-h | --help)
     mainCLI.py --version
 """
@@ -19,6 +20,7 @@ from docopt import docopt
 # source imports
 import dialogue
 from src import validate
+from src import benchmark_run
 
 
 def to_list(s):
@@ -105,13 +107,20 @@ def do_validate(arguments):
 def do_dialogue(arguments):
     dialogue.dialogue()
 
+def do_spectate(arguments):
+    with open(arguments['<config>'], 'r') as f:
+        args = json.loads(f.read())
+    s = benchmark_run.SpecJBBRun(**args)
+    return s.run()
+
 # dictionary of runnables
 # these are functions that take arguments from the
 # command line and do something with them.
 do = {
         'run': do_run,
         'validate': do_validate,
-        'dialogue' : do_dialogue
+        'dialogue' : do_dialogue,
+        'spectate': do_spectate,
         }
 
 if __name__ == "__main__":

--- a/mainCLI.py
+++ b/mainCLI.py
@@ -129,7 +129,6 @@ do = {
 
 if __name__ == "__main__":
     arguments = docopt(__doc__, version='SPECtate v0.1')
-    print(arguments)
     logging.basicConfig(level=logging.getLevelName(arguments['--level']))
 
     for key, func in do.items():

--- a/mainCLI.py
+++ b/mainCLI.py
@@ -3,9 +3,9 @@
 Usage:
     mainCLI.py run <config> [--props <props>]
     mainCLI.py validate <config>
+    mainCLI.py dialogue
     mainCLI.py (-h | --help)
     mainCLI.py --version
-    mainCLI.py dialogue
 """
 # library imports
 import json

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -37,11 +37,12 @@ class SpecJBBRun:
     def run(self):
         # setup jvms
         # we first need to setup the controller
+        controller_props = props['controller'] if isinstance(props['controller'], list) else props['controller']
+
         c = TaskRunner(self.props["jvm"],
-                *props['controller'] if isinstance(props['controller'], list) else props['controller'],
+                *controller_props,
                 '-jar {}'.format(self.props["specjbb"]["jar"]),
-                '-m MULTICONTROLLER',
-                )
+                '-m MULTICONTROLLER')
 
         # we need to setup the backends and transaction injectors
         def generate_backends_and_injectors():

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -155,8 +155,6 @@ class SpecJBBRun:
 
         pool.map(do, tasks)
 
-        # TODO: collect results
-
     def dump(self, level=logging.DEBUG):
         """
         Dumps info about this currently configured run.

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -14,13 +14,16 @@ class SpecJBBRun:
     Does a run!
     """
 
-    def __init__(self, types={}, props={}):
-        pass
+    def __init__(self, types=None, props=None):
+        if not types or not props:
+            raise InvalidRunConfigurationException
+        self.types = types
+        self.props = props
 
     def run(self):
         pass
 
-    def dump_info(self, level=logging.INFO):
+    def debug(self, logger=log, level=logging.DEBUG):
         """
         Dumps info about this currently configured run.
         """

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -54,7 +54,7 @@ class SpecJBBRun:
     def run(self):
         # setup jvms
         # we first need to setup the controller
-        controller_props = self.props['controller'] if isinstance(self.props['controller'], list) else self.props.get('controller', [])
+        controller_props = self.props['controller'] if 'controller' in self.props and isinstance(self.props['controller'], list) else self.props.get('controller', [])
 
         c = TaskRunner(self.props["jvm"],
                 '-jar {}'.format(self.props["jar"]),

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -59,11 +59,12 @@ class SpecJBBRun:
                         '-J={}'.format(uuid4()))
 
         # run benchmark
+        c.run()
+
         for task in generate_backends_and_injectors():
             task.run()
 
         # TODO: collect results
-        pass
 
     def dump(self, level=logging.DEBUG):
         """

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -38,16 +38,16 @@ class SpecJBBRun:
     def _generate_tasks(self):
         for group_id in range(self.props["backends"]):
             yield TaskRunner(self.props["jvm"],
-                '-jar {}'.format(self.props["specjbb"]["jar"]),
+                '-jar {0}'.format(self.props["specjbb"]["jar"]),
                 '-m BACKEND',
-                '-G={}'.format(group_id),
-                '-J={}'.format(uuid4()))
+                '-G={0}'.format(group_id),
+                '-J={0}'.format(uuid4()))
             for ti_num in range(self.props["injectors"]):
                 yield TaskRunner(self.props["jvm"],
-                    '-jar {}'.format(self.props["specjbb"]["jar"]),
+                    '-jar {0}'.format(self.props["specjbb"]["jar"]),
                     '-m TXINJECTOR',
-                    '-G={}'.format(group_id),
-                    '-J={}'.format(uuid4()))
+                    '-G={0}'.format(group_id),
+                    '-J={0}'.format(uuid4()))
 
     def run(self):
         # setup jvms
@@ -56,7 +56,7 @@ class SpecJBBRun:
 
         c = TaskRunner(self.props["jvm"],
                 *controller_props,
-                '-jar {}'.format(self.props["specjbb"]["jar"]),
+                '-jar {0}'.format(self.props["specjbb"]["jar"]),
                 '-m MULTICONTROLLER')
 
         self.log.info("begin benchmark")

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -72,6 +72,6 @@ class SpecJBBRun:
         Dumps info about this currently configured run.
         """
         def l(*a, **kw):
-            log.log(level, *a, extra={'run_id': self.run_id}, *kw)
+            log.log(level, *a, extra={'run_id': self.run_id}, **kw)
 
         l(vars(self))

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -40,16 +40,16 @@ class SpecJBBRun:
     def _generate_tasks(self):
         for group_id in range(self.props["backends"]):
             yield TaskRunner(self.props["jvm"],
-                '-jar {0}'.format(self.props["jar"]),
+                '-jar {}'.format(self.props["jar"]),
                 '-m BACKEND',
-                '-G={0}'.format(group_id),
-                '-J={0}'.format(uuid4()))
+                '-G={}'.format(group_id),
+                '-J={}'.format(uuid4()))
             for ti_num in range(self.props["injectors"]):
                 yield TaskRunner(self.props["jvm"],
-                    '-jar {0}'.format(self.props["jar"]),
+                    '-jar {}'.format(self.props["jar"]),
                     '-m TXINJECTOR',
-                    '-G={0}'.format(group_id),
-                    '-J={0}'.format(uuid4()))
+                    '-G={}'.format(group_id),
+                    '-J={}'.format(uuid4()))
 
     def run(self):
         # setup jvms
@@ -57,9 +57,9 @@ class SpecJBBRun:
         controller_props = self.props['controller'] if isinstance(self.props['controller'], list) else self.props.get('controller', [])
 
         c = TaskRunner(self.props["jvm"],
-                *controller_props,
-                '-jar {0}'.format(self.props["jar"]),
-                '-m MULTICONTROLLER')
+                '-jar {}'.format(self.props["jar"]),
+                '-m MULTICONTROLLER',
+                *controller_props)
 
         self.log.info("begin benchmark")
 

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -15,14 +15,37 @@ class InvalidRunConfigurationException(Exception):
 
 class TopologyConfiguration:
     def _full_options(self, options_dict):
-        return [self.jvm, "-jar", self.jar] + options_dict["options"]
+        return [self.jvm["path"], "-jar", self.jar] + self.jvm["options"] + options_dict["options"]
 
-    def __init__(self, controller=None, backends=None, injectors=None, jvm=None, jar=None):
-        if None in [backends, injectors, jvm, jar] or not isinstance(jvm, str) or not isinstance(jar, str):
+    @staticmethod
+    def from_dict(props):
+        if isinstance(props, TopologyConfiguration):
+            return props
+        elif isinstance(props, dict):
+            return TopologyConfiguration(**props)
+        else:
             raise Exception
 
-        self.jvm = jvm
+    def __init__(self, controller=None, backends=None, injectors=None, jvm=None, jar=None):
+        if None in [backends, injectors, jvm, jar] or not isinstance(jar, str):
+            raise Exception
+
         self.jar = jar
+
+        if isinstance(jvm, str):
+            self.jvm = {
+                    "path": jvm,
+                    "options": []
+                    }
+        elif isinstance(jvm, list):
+            self.jvm = {
+                    "path": jvm[0],
+                    "options": jvm[1:],
+                    }
+        elif isinstance(jvm, dict):
+            self.jvm = jvm
+        else:
+            raise Exception
 
         if controller is None:
             self.controller = {

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -2,8 +2,11 @@
 This module replaces `run.sh`.
 """
 
+from uuid import uuid4
 import logging
-logging.basicConfig(level=logging.DEBUG)
+
+FORMAT = '%(asctime)-15s run_id=%(run_id)s: %(message)s'
+logging.basicConfig(level=logging.DEBUG, format=FORMAT)
 log = logging.getLogger(__name__)
 
 class InvalidRunConfigurationException(Exception):
@@ -19,12 +22,19 @@ class SpecJBBRun:
             raise InvalidRunConfigurationException
         self.types = types
         self.props = props
+        self.run_id = uuid4()
 
     def run(self):
         pass
 
-    def debug(self, logger=log, level=logging.DEBUG):
+    def dump(self, level=logging.DEBUG):
         """
         Dumps info about this currently configured run.
         """
+        def l(*a, **kw):
+            log.log(level, *a, extra={'run_id': self.run_id}, *kw)
+
+        l('types: {}'.format(self.types))
+        l('props: {}'.format(self.props))
+
         pass

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -57,7 +57,7 @@ class TopologyConfiguration:
         elif isinstance(controller, list):
             self.controller = {
                     "count": 1,
-                    "options": controller,
+                    "options": ["-m", "MULTICONTROLLER"] + controller,
                 }
 
         if isinstance(backends, int):
@@ -146,14 +146,18 @@ class SpecJBBRun:
         # setup jvms
         # we first need to setup the controller
         c = TaskRunner(*self.props.controller_run_args())
+        c.start()
 
-        tasks = [c] + [ task for task in self._generate_tasks() ]
+        tasks = [ task for task in self._generate_tasks() ]
         pool = Pool(processes=len(tasks))
+
+        self.dump()
 
         # run benchmark
         self.log.info("begin benchmark")
 
         pool.map(do, tasks)
+        c.stop()
 
     def dump(self, level=logging.DEBUG):
         """

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -1,0 +1,27 @@
+"""
+This module replaces `run.sh`.
+"""
+
+import logging
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+class InvalidRunConfigurationException(Exception):
+    pass
+
+class SpecJBBRun:
+    """
+    Does a run!
+    """
+
+    def __init__(self, types={}, props={}):
+        pass
+
+    def run(self):
+        pass
+
+    def dump_info(self, level=logging.INFO):
+        """
+        Dumps info about this currently configured run.
+        """
+        pass

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -45,8 +45,8 @@ class SpecJBBRun:
             backend_jvm_id = uuid4()
             self.log.debug("constructing group {}".format(group_id))
             yield TaskRunner(self.props["jvm"],
-                '-jar {}'.format(self.props["jar"]),
-                '-m BACKEND',
+                '-jar', self.props["jar"],
+                '-m', 'BACKEND',
                 '-G={}'.format(group_id),
                 '-J={}'.format(backend_jvm_id))
 
@@ -56,7 +56,7 @@ class SpecJBBRun:
                 ti_jvm_id = uuid4()
                 self.log.debug("preparing injector in group {} with jvmid={}".format(group_id, ti_jvm_id))
                 yield TaskRunner(self.props["jvm"],
-                    '-jar {}'.format(self.props["jar"]),
+                    '-jar', self.props["jar"],
                     '-m TXINJECTOR',
                     '-G={}'.format(group_id),
                     '-J={}'.format(ti_jvm_id))
@@ -67,18 +67,20 @@ class SpecJBBRun:
         controller_props = self.props['controller'] if 'controller' in self.props and isinstance(self.props['controller'], list) else self.props.get('controller', [])
 
         c = TaskRunner(self.props["jvm"],
-                '-jar {}'.format(self.props["jar"]),
-                '-m MULTICONTROLLER',
+                '-jar', self.props["jar"],
+                '-m', 'MULTICONTROLLER',
                 *controller_props)
 
         self.log.info("begin benchmark")
 
         # run benchmark
         c.run()
-
-        for task in self._generate_tasks():
+        
+        tasks = [ task for task in self._generate_tasks() ]
+        for task in tasks:
             self.log.debug("starting task {}".format(task))
             task.start()
+            self.log.debug("started task {}".format(task))
 
         # TODO: collect results
 

--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -17,11 +17,21 @@ class SpecJBBRun:
     Does a run!
     """
 
-    def __init__(self, types=None, props=None):
-        if not types or not props:
+    def __init__(self, 
+            args=None,
+            annotations=None,
+            types=None,
+            translations=None,
+            default_props=None,
+            props=None):
+        if not types or not props or not args:
             raise InvalidRunConfigurationException
+
+        self.args = args
         self.types = types
+        self.translations = translations
         self.props = props
+
         self.run_id = uuid4()
 
     def run(self):
@@ -34,7 +44,6 @@ class SpecJBBRun:
         def l(*a, **kw):
             log.log(level, *a, extra={'run_id': self.run_id}, *kw)
 
-        l('types: {}'.format(self.types))
-        l('props: {}'.format(self.props))
+        l(vars(self))
 
         pass

--- a/src/task_runner.py
+++ b/src/task_runner.py
@@ -10,13 +10,13 @@ class TaskRunner:
             raise Exception
 
         self.path = path
-        options = itertools.chain(*options)
+        options = list(itertools.chain(options))
 
         for opt in options:
             if not isinstance(opt, str):
                 raise Exception
 
-        self.options = list(options)
+        self.options = options
         self.kw = popen_kw
 
         self.proc = None

--- a/src/task_runner.py
+++ b/src/task_runner.py
@@ -40,7 +40,7 @@ class TaskRunner:
         if not self.proc:
             return
 
-        self.proc.terminate()
+        return self.proc.terminate()
 
     def start(self):
         """

--- a/src/task_runner.py
+++ b/src/task_runner.py
@@ -19,6 +19,9 @@ class TaskRunner:
 
         self.proc = None
 
+    def __str__(self):
+        return "TaskRunner(path={}, options={}, kw={}, proc={})".format(self.path, self.options, self.kw, self.proc)
+
 
     def argument_list(self):
         return [self.path] + self.options

--- a/src/task_runner.py
+++ b/src/task_runner.py
@@ -10,7 +10,7 @@ class TaskRunner:
             raise Exception
 
         self.path = path
-        options = list(itertools.chain(options))
+        options = list(options)
 
         for opt in options:
             if not isinstance(opt, str):

--- a/src/task_runner.py
+++ b/src/task_runner.py
@@ -1,0 +1,10 @@
+
+class TaskRunner:
+    """
+    Runs a specified task with the given options.
+    """
+    def __init__(self, exec_opts, *extra):
+        pass
+
+    def run(self):
+        pass

--- a/src/task_runner.py
+++ b/src/task_runner.py
@@ -1,10 +1,25 @@
+import subprocess
 
 class TaskRunner:
     """
     Runs a specified task with the given options.
     """
-    def __init__(self, exec_opts, *extra):
-        pass
+    def __init__(self, path, *options, **kw):
+        if not path:
+            raise Exception
+
+        self.path = path
+
+        for opt in options:
+            if not isinstance(opt, str):
+                raise Exception
+
+        self.options = list(options)
+        self.kw = kw
+
+
+    def argument_list(self):
+        return [self.path] + self.options
 
     def run(self):
-        pass
+        return subprocess.run(self.argument_list(), stdin=True, check=True, **self.kw)

--- a/src/task_runner.py
+++ b/src/task_runner.py
@@ -4,7 +4,7 @@ class TaskRunner:
     """
     Runs a specified task with the given options.
     """
-    def __init__(self, path, *options, **kw):
+    def __init__(self, path, *options, **popen_kw):
         if not path:
             raise Exception
 
@@ -15,11 +15,38 @@ class TaskRunner:
                 raise Exception
 
         self.options = list(options)
-        self.kw = kw
+        self.kw = popen_kw
+
+        self.proc = None
 
 
     def argument_list(self):
         return [self.path] + self.options
 
-    def run(self):
-        return subprocess.run(self.argument_list(), stdin=True, check=True, **self.kw)
+    def run(self, timeout=-1):
+        """
+        Runs a task synchronously and returns data from standard out.
+        """
+        self.start()
+
+        out, err = self.proc.communicate(timeout)
+
+        return out
+
+    def stop(self):
+        """
+        Stops this running task, if applicable.
+        """
+        if not self.proc:
+            return
+
+        self.proc.terminate()
+
+    def start(self):
+        """
+        Starts a configured task, if not already running.
+        """
+        if self.proc:
+            return
+
+        self.proc = subprocess.Popen(self.argument_list(), **self.kw)

--- a/src/task_runner.py
+++ b/src/task_runner.py
@@ -1,4 +1,5 @@
 import subprocess
+import itertools
 
 class TaskRunner:
     """
@@ -9,6 +10,7 @@ class TaskRunner:
             raise Exception
 
         self.path = path
+        options = itertools.chain(*options)
 
         for opt in options:
             if not isinstance(opt, str):

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -3,7 +3,7 @@ import json
 import testfixtures
 import logging
 
-from src.benchmark_run import SpecJBBRun, InvalidRunConfigurationException
+from src.benchmark_run import SpecJBBRun, TopologyConfiguration, InvalidRunConfigurationException
 
 class TestBenchmarkRun(unittest.TestCase):
     valid_props = {
@@ -50,4 +50,68 @@ class TestBenchmarkRun(unittest.TestCase):
             r.dump()
             # need to have some actual logging output
             self.assertTrue(l.actual())
+
+class TestTopologyConfiguration(unittest.TestCase):
+    valid_props = [
+            {
+		    "backends": 2,
+		    "injectors": 4,
+		    "controller": ["arg1", "arg2"],
+		    "jvm": "java",
+		    "jar": "env/Main.jar"
+                },
+            {
+		    "backends": {
+                        "count": 2,
+                        "options": ["arg1", "arg2"],
+                        },
+		    "injectors": 4,
+		    "controller": ["arg1", "arg2"],
+		    "jvm": "java",
+		    "jar": "env/Main.jar"
+                },
+            {
+		    "backends": 2,
+		    "injectors": {
+                        "count": 4,
+                        "options": ["arg1", "arg2"],
+                        },
+		    "controller": ["arg1", "arg2"],
+		    "jvm": "java",
+		    "jar": "env/Main.jar"
+                },
+            {
+		    "backends": 2,
+		    "injectors": 4,
+		    "jvm": "java",
+		    "jar": "env/Main.jar"
+                },
+            ]
+
+    invalid_props = [
+
+            ]
+    def test_valid_props_work(self):
+        for valid in self.valid_props:
+            TopologyConfiguration(**valid)
+
+    def test_invalid_props_dont_work(self):
+        for invalid in self.invalid_props:
+            with self.assertRaises(Exception):
+                TopologyConfiguration(**invalid)
+
+    def test_valid_give_run_options(self):
+        t = TopologyConfiguration(**{
+            "backends": 2,
+            "injectors": 4,
+            "jvm": "java",
+            "jar": "env/Main.jar",
+                })
+
+        self.assertTrue("env/Main.jar" in t.controller_run_args())
+        self.assertTrue("env/Main.jar" in t.backend_run_args())
+        self.assertTrue("env/Main.jar" in t.ti_run_args())
+
+
+
 

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -110,7 +110,7 @@ class TestTopologyConfiguration(unittest.TestCase):
 
         self.assertTrue("env/Main.jar" in t.controller_run_args())
         self.assertTrue("env/Main.jar" in t.backend_run_args())
-        self.assertTrue("env/Main.jar" in t.ti_run_args())
+        self.assertTrue("env/Main.jar" in t.injector_run_args())
 
 
 

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -32,9 +32,7 @@ class TestBenchmarkRun(unittest.TestCase):
                 "path": "/path/to/jvm",
                 "options": [], # to be condensed into a string later
             },
-            "specjbb": {
-                "jar": "/path/to/jar",
-            },
+            "jar": "/path/to/jar",
         }
 
     def test_run_with_empty_config_gives_exception(self):

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -113,6 +113,3 @@ class TestTopologyConfiguration(unittest.TestCase):
             self.assertTrue("java" in f())
             self.assertEqual("java", f()[0])
 
-
-
-

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -7,23 +7,23 @@ from src.benchmark_run import SpecJBBRun, TopologyConfiguration, InvalidRunConfi
 
 class TestBenchmarkRun(unittest.TestCase):
     valid_props = {
-        "args": [
-            "Arg1",
-            "Arg2",
-            ],
-        "annotations": {
-            "Arg1": "This is the first argument",
-            "Arg2": "This is the second argument",
-            },
-        "types": {
-            "Arg1": "string",
-            "Arg2": "int",
-            },
-        "translations": {
-            "Arg1": "com.spec.prop1",
-            },
-        "default_props": {},
-        }
+            "args": [
+                "Arg1",
+                "Arg2",
+                ],
+            "annotations": {
+                "Arg1": "This is the first argument",
+                "Arg2": "This is the second argument",
+                },
+            "types": {
+                "Arg1": "string",
+                "Arg2": "int",
+                },
+            "translations": {
+                "Arg1": "com.spec.prop1",
+                },
+            "default_props": {},
+            }
 
     valid_tate_props = {
             "backends": 2,
@@ -31,9 +31,9 @@ class TestBenchmarkRun(unittest.TestCase):
             "jvm": {
                 "path": "/path/to/jvm",
                 "options": [], # to be condensed into a string later
-            },
+                },
             "jar": "/path/to/jar",
-        }
+            }
 
     def test_run_with_empty_config_gives_exception(self):
         with self.assertRaises(InvalidRunConfigurationException):
@@ -52,59 +52,59 @@ class TestBenchmarkRun(unittest.TestCase):
 class TestTopologyConfiguration(unittest.TestCase):
     valid_props = [
             {
-		    "backends": 2,
-		    "injectors": 4,
-		    "controller": ["arg1", "arg2"],
-		    "jvm": "java",
-		    "jar": "env/Main.jar",
+                "backends": 2,
+                "injectors": 4,
+                "controller": ["arg1", "arg2"],
+                "jvm": "java",
+                "jar": "env/Main.jar",
                 },
             {
-		    "backends": {
-                        "count": 2,
-                        "options": ["arg1", "arg2"],
-                        },
-		    "injectors": 4,
-		    "controller": ["arg1", "arg2"],
-		    "jvm": "java",
-		    "jar": "env/Main.jar",
+                "backends": {
+                    "count": 2,
+                    "options": ["arg1", "arg2"],
+                    },
+                "injectors": 4,
+                "controller": ["arg1", "arg2"],
+                "jvm": "java",
+                "jar": "env/Main.jar",
                 },
             {
-		    "backends": 2,
-		    "injectors": {
-                        "count": 4,
-                        "options": ["arg1", "arg2"],
-                        },
-		    "controller": ["arg1", "arg2"],
-		    "jvm": "java",
-		    "jar": "env/Main.jar",
+                "backends": 2,
+                "injectors": {
+                    "count": 4,
+                    "options": ["arg1", "arg2"],
+                    },
+                "controller": ["arg1", "arg2"],
+                "jvm": "java",
+                "jar": "env/Main.jar",
                 },
             {
-		    "backends": 2,
-		    "injectors": 4,
-		    "jvm": "java",
-		    "jar": "env/Main.jar",
+                "backends": 2,
+                "injectors": 4,
+                "jvm": "java",
+                "jar": "env/Main.jar",
                 },
             {
-		    "backends": 2,
-		    "injectors": 4,
-		    "jvm": {
-                        "path": "java",
-                        "options": ["any", "options"],
-                        },
-		    "jar": "env/Main.jar",
+                "backends": 2,
+                "injectors": 4,
+                "jvm": {
+                    "path": "java",
+                    "options": ["any", "options"],
+                    },
+                "jar": "env/Main.jar",
                 },
             ]
 
     invalid_props = [
             {
-		    "injectors": 4,
-		    "jvm": "java",
-		    "jar": "env/Main.jar"
+                "injectors": 4,
+                "jvm": "java",
+                "jar": "env/Main.jar"
                 },
             {
-		    "backends": 4,
-		    "jvm": "java",
-		    "jar": "env/Main.jar"
+                "backends": 4,
+                "jvm": "java",
+                "jar": "env/Main.jar"
                 },
 
             ]
@@ -123,7 +123,7 @@ class TestTopologyConfiguration(unittest.TestCase):
             "injectors": 4,
             "jvm": "java",
             "jar": "env/Main.jar",
-                })
+            })
 
         for f in [t.controller_run_args, t.backend_run_args, t.injector_run_args]:
             self.assertTrue("env/Main.jar" in f())

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -108,9 +108,10 @@ class TestTopologyConfiguration(unittest.TestCase):
             "jar": "env/Main.jar",
                 })
 
-        self.assertTrue("env/Main.jar" in t.controller_run_args())
-        self.assertTrue("env/Main.jar" in t.backend_run_args())
-        self.assertTrue("env/Main.jar" in t.injector_run_args())
+        for f in [t.controller_run_args, t.backend_run_args, t.injector_run_args]:
+            self.assertTrue("env/Main.jar" in f())
+            self.assertTrue("java" in f())
+            self.assertEqual("java", f()[0])
 
 
 

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -1,0 +1,9 @@
+import unittest
+import json
+
+from src.benchmark_run import SpecJBBRun, InvalidRunConfigurationException
+
+class TestBenchmarkRun(unittest.TestCase):
+    def test_run_with_empty_config_gives_exception(self):
+        with self.assertRaises(InvalidRunConfigurationException):
+            r = SpecJBBRun()

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -1,6 +1,7 @@
 import unittest
 import json
 import testfixtures
+import logging
 
 from src.benchmark_run import SpecJBBRun, InvalidRunConfigurationException
 
@@ -38,7 +39,7 @@ class TestBenchmarkRun(unittest.TestCase):
         except Exception as e:
             self.fail(e)
         with testfixtures.LogCapture() as l:
-            r.debug(logger=l)
+            r.dump()
             # need to have some actual logging output
             self.assertTrue(l.actual())
 

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -86,9 +86,28 @@ class TestTopologyConfiguration(unittest.TestCase):
 		    "jvm": "java",
 		    "jar": "env/Main.jar"
                 },
+            {
+		    "backends": 2,
+		    "injectors": 4,
+		    "jvm": {
+                        "path": "java",
+                        "options": ["any", "options"],
+                        },
+		    "jar": "env/Main.jar",
+                },
             ]
 
     invalid_props = [
+            {
+		    "injectors": 4,
+		    "jvm": "java",
+		    "jar": "env/Main.jar"
+                },
+            {
+		    "backends": 4,
+		    "jvm": "java",
+		    "jar": "env/Main.jar"
+                },
 
             ]
     def test_valid_props_work(self):

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -31,7 +31,10 @@ class TestBenchmarkRun(unittest.TestCase):
             "jvm": {
                 "path": "/path/to/jvm",
                 "options": [], # to be condensed into a string later
-            }
+            },
+            "specjbb": {
+                "jar": "/path/to/jar",
+            },
         }
 
     def test_run_with_empty_config_gives_exception(self):

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -6,12 +6,23 @@ import logging
 from src.benchmark_run import SpecJBBRun, InvalidRunConfigurationException
 
 class TestBenchmarkRun(unittest.TestCase):
-    valid_types = {
-        "args": [],
-        "annotations": {},
-        "types": {},
-        "translations": {},
-        "props": {}
+    valid_props = {
+        "args": [
+            "Arg1",
+            "Arg2",
+            ],
+        "annotations": {
+            "Arg1": "This is the first argument",
+            "Arg2": "This is the second argument",
+            },
+        "types": {
+            "Arg1": "string",
+            "Arg2": "int",
+            },
+        "translations": {
+            "Arg1": "com.spec.prop1",
+            },
+        "default_props": {},
         }
 
     valid_tate_props = {
@@ -28,16 +39,10 @@ class TestBenchmarkRun(unittest.TestCase):
             r = SpecJBBRun()
 
     def test_run_with_valid_configuration(self):
-        try:
-            r = SpecJBBRun(types=self.valid_types, props=self.valid_tate_props)
-        except Exception as e:
-            self.fail(e)
+        SpecJBBRun(props=self.valid_tate_props, **self.valid_props)
 
     def test_valid_run_can_dump_info(self):
-        try:
-            r = SpecJBBRun(types=self.valid_types, props=self.valid_tate_props)
-        except Exception as e:
-            self.fail(e)
+        r = SpecJBBRun(props=self.valid_tate_props, **self.valid_props)
         with testfixtures.LogCapture() as l:
             r.dump()
             # need to have some actual logging output

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -1,9 +1,44 @@
 import unittest
 import json
+import testfixtures
 
 from src.benchmark_run import SpecJBBRun, InvalidRunConfigurationException
 
 class TestBenchmarkRun(unittest.TestCase):
+    valid_types = {
+        "args": [],
+        "annotations": {},
+        "types": {},
+        "translations": {},
+        "props": {}
+        }
+
+    valid_tate_props = {
+            "backends": 2,
+            "injectors": 14,
+            "jvm": {
+                "path": "/path/to/jvm",
+                "options": [], # to be condensed into a string later
+            }
+        }
+
     def test_run_with_empty_config_gives_exception(self):
         with self.assertRaises(InvalidRunConfigurationException):
             r = SpecJBBRun()
+
+    def test_run_with_valid_configuration(self):
+        try:
+            r = SpecJBBRun(types=self.valid_types, props=self.valid_tate_props)
+        except Exception as e:
+            self.fail(e)
+
+    def test_valid_run_can_dump_info(self):
+        try:
+            r = SpecJBBRun(types=self.valid_types, props=self.valid_tate_props)
+        except Exception as e:
+            self.fail(e)
+        with testfixtures.LogCapture() as l:
+            r.debug(logger=l)
+            # need to have some actual logging output
+            self.assertTrue(l.actual())
+

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -56,7 +56,7 @@ class TestTopologyConfiguration(unittest.TestCase):
 		    "injectors": 4,
 		    "controller": ["arg1", "arg2"],
 		    "jvm": "java",
-		    "jar": "env/Main.jar"
+		    "jar": "env/Main.jar",
                 },
             {
 		    "backends": {
@@ -66,7 +66,7 @@ class TestTopologyConfiguration(unittest.TestCase):
 		    "injectors": 4,
 		    "controller": ["arg1", "arg2"],
 		    "jvm": "java",
-		    "jar": "env/Main.jar"
+		    "jar": "env/Main.jar",
                 },
             {
 		    "backends": 2,
@@ -76,13 +76,13 @@ class TestTopologyConfiguration(unittest.TestCase):
                         },
 		    "controller": ["arg1", "arg2"],
 		    "jvm": "java",
-		    "jar": "env/Main.jar"
+		    "jar": "env/Main.jar",
                 },
             {
 		    "backends": 2,
 		    "injectors": 4,
 		    "jvm": "java",
-		    "jar": "env/Main.jar"
+		    "jar": "env/Main.jar",
                 },
             {
 		    "backends": 2,

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -30,7 +30,3 @@ class TestTaskRunner(unittest.TestCase):
         t = TaskRunner("echo", "hello", "world")
         t.run()
 
-    def test_run_with_list_in_arg_is_unpacked(self):
-        t = TaskRunner("echo", ["hello", "world"], "this", "should", "be unpacked")
-        t.run()
-

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -1,0 +1,41 @@
+import unittest
+
+from src.task_runner import TaskRunner
+
+class TestTaskRunner(unittest.TestCase):
+    valid_exec = {
+            'path': '/some/path',
+            'options': []
+            },
+
+    valid_options = [
+            valid_exec,
+            ]
+
+    invalid_options = [
+            [ # missing path
+                {
+                    'options': []
+                    },
+                ],
+            [ # missing options
+                {
+                    'path': '/some/path'
+                    },
+                ],
+            [ # given non-string arguments
+                valid_exec,
+                2,
+                None,
+                False,
+                ],
+            ]
+
+    def test_init_with_valid_options_works(self):
+        TaskRunner(*self.valid_options)
+
+    def test_init_with_invalid_options_fails(self):
+        with self.assertRaises(Exception):
+            for invalid in self.invalid_options:
+                TaskRunner(*invalid)
+

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -30,3 +30,7 @@ class TestTaskRunner(unittest.TestCase):
         t = TaskRunner("echo", "hello", "world")
         t.run()
 
+    def test_run_with_list_in_arg_is_unpacked(self):
+        t = TaskRunner("echo", ["hello", "world"], "this", "should", "be unpacked")
+        t.run()
+

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -26,7 +26,7 @@ class TestTaskRunner(unittest.TestCase):
             for invalid in self.invalid_options:
                 TaskRunner(*invalid)
 
-    def test_run_does_stuff(self):
+    def test_run_actually_runs(self):
         t = TaskRunner("echo", "hello", "world")
         t.run()
 

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -3,28 +3,15 @@ import unittest
 from src.task_runner import TaskRunner
 
 class TestTaskRunner(unittest.TestCase):
-    valid_exec = {
-            'path': '/some/path',
-            'options': []
-            },
-
     valid_options = [
-            valid_exec,
+            "echo",
+            "hello",
+            "world",
             ]
 
     invalid_options = [
-            [ # missing path
-                {
-                    'options': []
-                    },
-                ],
-            [ # missing options
-                {
-                    'path': '/some/path'
-                    },
-                ],
             [ # given non-string arguments
-                valid_exec,
+                "echo",
                 2,
                 None,
                 False,
@@ -32,10 +19,14 @@ class TestTaskRunner(unittest.TestCase):
             ]
 
     def test_init_with_valid_options_works(self):
-        TaskRunner(*self.valid_options)
+        TaskRunner(self.valid_options)
 
     def test_init_with_invalid_options_fails(self):
         with self.assertRaises(Exception):
             for invalid in self.invalid_options:
                 TaskRunner(*invalid)
+
+    def test_run_does_stuff(self):
+        t = TaskRunner("echo", "hello", "world")
+        t.run()
 


### PR DESCRIPTION
# Overview
For a super basic setup, and so that we can start talking on it, I decided to do the bare minimum for SPECtate to be able to do a SPECjbb run. Given a `json` file with some keys (example below), the `SpecJBBRun` class will:
1. Ensure everything looks like it should (typechecking, etc)
1. Populate some defaults
1. Create a `TopologyConfiguration` which will handle various run arguments
1. Setup each of the JVM for a MultiJVM run:
    * Controller, with proper run arguments
    * Backends, with proper group IDs and JVM IDs
    * Transaction Injectors, with proper group assignments and JVM IDs
1. Run the benchmark

# Running
With the following file (`tate_props.json`):
```
{
            "args": [],
            "annotations": {},
            "types": {},
            "translations": {},
            "default_props": {},
            "props": {
		    "backends": 2,
		    "injectors": 4,
		    "controller": ["arg1", "arg2"],
		    "jvm": "echo",
		    "jar": "specjbb2015.jar"
	    }
}
```

You can do:
```
$ python mainCLI.py spectate tate_props.json
```
And `echo` will be run with the various arguments that would be passed to a jvm.