### PR TITLE
Add one more level of example validation

### DIFF
--- a/tests/test_mainCLI.py
+++ b/tests/test_mainCLI.py
@@ -3,7 +3,12 @@ import json
 
 import mainCLI as main
 
-example_configuration = json.loads(open("example_config.json", "r").read())["specjbb"]
+example_config = json.loads(open("example_config.json", "r").read())
+
+if "specjbb" not in example_config:
+    raise Exception("expected specjbb to be in the example - either update this test or fix the example!")
+
+example_configuration = example_config["specjbb"]
 
 class TestMain(unittest.TestCase):
     def test_to_list_gives_arguments(self):


### PR DESCRIPTION
Opened with #66 and addresses #69. Adds a somewhat more helpful exception for failing Travis builds if the example changes.