### PR TITLE
gui/mainGUI can be called from root dir and from gui dir

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,4 @@
+from os.path import dirname, basename, isfile
+import glob
+modules = glob.glob(dirname('../')+"/*.py")
+__all__ = [ basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]

--- a/gui/mainGUI.py
+++ b/gui/mainGUI.py
@@ -1,13 +1,10 @@
 import os
 import sys
-sys.path.append('..')
-sys.path.append('gui/')
-sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 from tkinter import *
 from tkinter import filedialog
 from tkinter import messagebox
 import json
-import mainCLI as cli
+
 
 try:
     with open("gui/properties.json") as properties_file:

--- a/gui/mainGUI.py
+++ b/gui/mainGUI.py
@@ -1,15 +1,20 @@
 import os
 import sys
 sys.path.append('..')
+sys.path.append('gui/')
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 from tkinter import *
 from tkinter import filedialog
 from tkinter import messagebox
 import json
-from gui.multiListBox import MultiColumnListbox
 import mainCLI as cli
 
-with open("properties.json") as properties_file:
-    properties = json.load(properties_file)
+try:
+    with open("gui/properties.json") as properties_file:
+        properties = json.load(properties_file)
+except:
+    with open("properties.json") as properties_file:
+        properties = json.load(properties_file)
 
 run_list = ['Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3', 'Run1', 'Run2', 'Run3']
 


### PR DESCRIPTION
Before, mainGUI would have to be called from SPECtate/gui, otherwise `ModuleNotFound` errors would occur when attempting to import mainCLI. 

These changes allow `mainGUI.py` to be called from project root directory. 