### PR TITLE
Add pip cache per https://docs.travis-ci.com/user/caching/#pip-cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ deploy:
   provider: releases
   api_key: ${GITHUB_OAUTH_TOKEN}
   file:
-    - dist/main
+    - dist/mainCLI
   skip_cleanup: true
+  prerelease: true
   on:
     branch: 
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+cache: pip
 os:
   - linux
 install:


### PR DESCRIPTION
As the title says, adds caching support for Travis CI builds using: <https://docs.travis-ci.com/user/caching/#pip-cache>.