### PR TITLE
Update validator and examples to use proper keys

### DIFF
--- a/example_spectate_config.json
+++ b/example_spectate_config.json
@@ -1,5 +1,5 @@
 {
-	"templates": {
+	"TemplateData": {
 		"HBIR": {
 			"args": [
 				"arg1",
@@ -25,7 +25,7 @@
 
 		}
 	},
-	"runs": [
+	"RunList": [
 		{
 			"template_name": "HBIR BUT BETTER",
 			"args": {

--- a/example_spectate_config.json
+++ b/example_spectate_config.json
@@ -27,7 +27,7 @@
 	},
 	"RunList": [
 		{
-			"template_name": "HBIR BUT BETTER",
+			"template_type": "HBIR BUT BETTER",
 			"args": {
 				"arg1": "value 1",
 				"arg2": "value 1",
@@ -35,7 +35,7 @@
 			}
 		},
 		{
-			"template_name": "HBIR",
+			"template_type": "HBIR",
 			"args": {
 				"arg1": 4,
 				"arg2": false
@@ -43,7 +43,7 @@
 
 		},
 		{
-			"template_name": "HBIR",
+			"template_type": "HBIR",
 			"args": {
 				"arg1": 4,
 				"arg2": false

--- a/src/validate.py
+++ b/src/validate.py
@@ -57,19 +57,19 @@ RunConfigSchema = Schema({
     })
 
 SpectateConfig = Schema({
-    "templates": { 
+    "TemplateData": { 
         is_stringy: TemplateSchema,
     },
-    "runs": [RunConfigSchema],
+    "RunList": [RunConfigSchema],
     })
 
 def validate(unvalidated):
     d = SpectateConfig.validate(unvalidated)
 
     # each of the args that appear in the runs,
-    for run in d["runs"]:
+    for run in d["RunList"]:
         # for the templates they pull from,
-        t = d["templates"][run["template_name"]]
+        t = d["TemplateData"][run["template_name"]]
 
         # they need to appear in the template
         for arg in run["args"]:
@@ -83,7 +83,7 @@ def validate(unvalidated):
                 return None
 
     # for each template,
-    for template in d["templates"].values():
+    for template in d["TemplateData"].values():
         # all of the translations need to refer to
         # arguments specified by the user
         if "translations" in template:

--- a/src/validate.py
+++ b/src/validate.py
@@ -47,7 +47,7 @@ TemplateSchema = Schema({
     })
 
 RunConfigSchema = Schema({
-    "template_name": is_stringy,
+    "template_type": is_stringy,
     "args": {
         Optional(is_stringy): object,
         },
@@ -69,7 +69,7 @@ def validate(unvalidated):
     # each of the args that appear in the runs,
     for run in d["RunList"]:
         # for the templates they pull from,
-        t = d["TemplateData"][run["template_name"]]
+        t = d["TemplateData"][run["template_type"]]
 
         # they need to appear in the template
         for arg in run["args"]:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -50,7 +50,7 @@ class TestSpectateConfigValidator(TestCase):
                 "TemplateData": {},
                 "RunList": [
                     {
-                        "template_name": "NONE",
+                        "template_type": "NONE",
                         "args": { "a": "b" },
                         }
                     ],
@@ -68,7 +68,7 @@ class TestSpectateConfigValidator(TestCase):
                 },
             "RunList": [
                 {
-                    "template_name": "example",
+                    "template_type": "example",
                     "args": {
                         "a": "b",
                         "arg1": 5,
@@ -95,7 +95,7 @@ class TestSpectateConfigValidator(TestCase):
             },
             "RunList": [
                 {
-                    "template_name": "example",
+                    "template_type": "example",
                     "args": {
                         "arg1": 5,
                         },

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -33,7 +33,7 @@ class TestSpectateConfigValidator(TestCase):
 
     def test_templates_with_extra_translations_dont_validate(self):
         self.assertFalse(validate({
-            "templates": {
+            "TemplateData": {
                 "example": {
                     "args": [],
                     "translations": { 
@@ -41,14 +41,14 @@ class TestSpectateConfigValidator(TestCase):
                         },
                     },
                 },
-            "runs": [],
+            "RunList": [],
             }))
 
     def test_there_should_be_templates_if_there_are_runs(self):
         with self.assertRaises(Exception):
             self.assertFalse(validate({
-                "templates": {},
-                "runs": [
+                "TemplateData": {},
+                "RunList": [
                     {
                         "template_name": "NONE",
                         "args": { "a": "b" },
@@ -58,7 +58,7 @@ class TestSpectateConfigValidator(TestCase):
 
     def test_runs_with_extra_args_fail_to_validate(self):
         self.assertFalse(validate({
-            "templates": {
+            "TemplateData": {
                 "example": {
                     "args": [],
                     "translations": { 
@@ -66,7 +66,7 @@ class TestSpectateConfigValidator(TestCase):
                         },
                     },
                 },
-            "runs": [
+            "RunList": [
                 {
                     "template_name": "example",
                     "args": {
@@ -79,7 +79,7 @@ class TestSpectateConfigValidator(TestCase):
 
     def test_runs_with_ommitted_with_no_defaults_fail_to_validate(self):
         self.assertFalse(validate({
-            "templates": {
+            "TemplateData": {
                 "example": {
                     "args": [
                         "arg1",
@@ -93,7 +93,7 @@ class TestSpectateConfigValidator(TestCase):
                     },
                 },
             },
-            "runs": [
+            "RunList": [
                 {
                     "template_name": "example",
                     "args": {
@@ -105,7 +105,7 @@ class TestSpectateConfigValidator(TestCase):
 
     def test_runs_with_extra_annotations_fail_to_validate(self):
         self.assertFalse(validate({
-            "templates": {
+            "TemplateData": {
                 "example": {
                     "args": [
                         "arg1",
@@ -116,5 +116,5 @@ class TestSpectateConfigValidator(TestCase):
                         },
                 },
             },
-            "runs": []
+            "RunList": []
             }))


### PR DESCRIPTION
The validator was built on some wrong keys, this updates those keys and their usage to match the Tate config as it's described in the wiki. 