### PR TITLE
(GUI) User can create runs

### DIFF
--- a/gui/mainGUI.py
+++ b/gui/mainGUI.py
@@ -188,9 +188,8 @@ class MainWindow(Frame):
         _, yoffset, _, height = widget.bbox(index)
         if event.y > height + yoffset + 5:
             return
-        selection = self.listbox.curselection()
-        # print(self.listbox.get(self.listbox.curselection()))
 
+        selection = self.listbox.curselection()
         if index not in selection:
             self.listbox.selection_clear(0, END)
         self.listbox.select_set(index)

--- a/gui/mainGUI.py
+++ b/gui/mainGUI.py
@@ -198,8 +198,11 @@ class MainWindow(Frame):
         self.popup_menu.tk_popup(event.x_root, event.y_root)
 
     def delete_selected(self, selection):
-        for item in selection[::-1]:
-            # @todo: RunManager call here
+        # for item in selection[::-1]:
+        #     # @todo: RunManager call here
+        #     self.listbox.delete(item)
+        for item in selection:
+            removed = self.run_manager.remove_run(tag_to_remove=self.listbox.get(self.listbox.curselection()))
             self.listbox.delete(item)
 
     def duplicate_selected(self, selection):
@@ -254,6 +257,7 @@ class MainWindow(Frame):
         # self.run_manager.insert_into_config_list("RunList", run)
 
     def save_group(self):
+        # @todo: is this needed?
         # save stuff
         pass
 

--- a/gui/mainGUI.py
+++ b/gui/mainGUI.py
@@ -121,7 +121,7 @@ class MainWindow(Frame):
             self.canvas.destroy()
             try:
                 self.tater = PhotoImage(file="tater.pgm").zoom(5).subsample(50)
-            except :
+            except:
                 self.tater = PhotoImage(file="gui/tater.pgm").zoom(5).subsample(50)
             self.canvas = Canvas(self.right_frame,
                                  width=80,
@@ -189,6 +189,8 @@ class MainWindow(Frame):
         if event.y > height + yoffset + 5:
             return
         selection = self.listbox.curselection()
+        # print(self.listbox.get(self.listbox.curselection()))
+
         if index not in selection:
             self.listbox.selection_clear(0, END)
         self.listbox.select_set(index)
@@ -197,11 +199,14 @@ class MainWindow(Frame):
 
     def delete_selected(self, selection):
         for item in selection[::-1]:
+            # @todo: RunManager call here
             self.listbox.delete(item)
 
     def duplicate_selected(self, selection):
         for item in selection:
-            self.listbox.insert(END, self.listbox.get(item))
+            inserted = self.run_manager.duplicate_run(from_tag=self.listbox.get(self.listbox.curselection()))
+            if inserted is not None and isinstance(inserted, dict):
+                self.listbox.insert(END, inserted["args"]["Tag"])
 
     def save_as(self):
         self.run_manager.write_to_file()

--- a/gui/mainGUI.py
+++ b/gui/mainGUI.py
@@ -78,9 +78,10 @@ class MainWindow(Frame):
         i = 0
 
         run_list = self.run_manager.get_run_list_tags()
-        while i < len(run_list):
-            self.listbox.insert(i, run_list[i])
-            i += 1
+        if run_list is not None:
+            while i < len(run_list):
+                self.listbox.insert(i, run_list[i])
+                i += 1
 
     def publish_menu(self):
         self.menu_bar = Menu(self.master)
@@ -118,7 +119,10 @@ class MainWindow(Frame):
         entries = {}
         if self.canvas is not None:
             self.canvas.destroy()
-            self.tater = PhotoImage(file="tater.pgm").zoom(5).subsample(50)
+            try:
+                self.tater = PhotoImage(file="tater.pgm").zoom(5).subsample(50)
+            except :
+                self.tater = PhotoImage(file="gui/tater.pgm").zoom(5).subsample(50)
             self.canvas = Canvas(self.right_frame,
                                  width=80,
                                  height=self.height,

--- a/gui/mainGUI.py
+++ b/gui/mainGUI.py
@@ -29,6 +29,7 @@ class MainWindow(Frame):
                        'frame': 'white',
                        'entry': 'white',
                        'text': 'white'}
+        self.font = "Calibri"
         Frame.__init__(self, *args, **kwargs)
         self.form, self.arg_label, self.tater, self.new_run_window, self.menu_bar = None, None, None, None, None
         self.run_manager = RunManager(config_file=None)
@@ -83,6 +84,13 @@ class MainWindow(Frame):
                 self.listbox.insert(i, run_list[i])
                 i += 1
 
+    def create_tag(self):
+        """
+        Will be a naming convention for creating a run tag.
+        :return:
+        """
+        pass
+
     def publish_menu(self):
         self.menu_bar = Menu(self.master)
 
@@ -93,7 +101,7 @@ class MainWindow(Frame):
                               command=lambda: self.create_new_run())
         file_menu.add_command(label=properties["commands"]["file"]["items"]["new_runtype"], command='')
         file_menu.add_command(label=properties["commands"]["file"]["items"]["save"],
-                              command=lambda: self.create_new_run)
+                              command=lambda: self.save_as)
         file_menu.add_command(label=properties["commands"]["file"]["items"]["save_as"], command=lambda: self.save_as)
         file_menu.add_command(label=properties["commands"]["file"]["items"]["import_config"],
                               command=lambda: self.import_runlist)
@@ -200,13 +208,14 @@ class MainWindow(Frame):
         # for item in selection[::-1]:
         #     # @todo: RunManager call here
         #     self.listbox.delete(item)
-        for item in selection:
-            removed = self.run_manager.remove_run(tag_to_remove=self.listbox.get(self.listbox.curselection()))
+        # iterate from end to beginning, loop
+        for item in selection[::-1]:
+            removed = self.run_manager.remove_run(tag_to_remove=self.listbox.get(item))
             self.listbox.delete(item)
 
     def duplicate_selected(self, selection):
         for item in selection:
-            inserted = self.run_manager.duplicate_run(from_tag=self.listbox.get(self.listbox.curselection()))
+            inserted = self.run_manager.duplicate_run(from_tag=self.listbox.get(item))
             if inserted is not None and isinstance(inserted, dict):
                 self.listbox.insert(END, inserted["args"]["Tag"])
 

--- a/gui/run_manager.py
+++ b/gui/run_manager.py
@@ -120,9 +120,7 @@ class RunManager:
 
     def remove_run(self, tag_to_remove):
         if self.initialized():
-            print("Before Remove: {}".format(self.get_run_list()))
             self.get_run_from_list(tag_to_find=tag_to_remove, action="del")
-            print("After Remove: {}".format(self.get_run_list()))
 
     def get_template_fields(self):
         """

--- a/gui/run_manager.py
+++ b/gui/run_manager.py
@@ -85,7 +85,7 @@ class RunManager:
         """
         if run_type not in self.get_template_types()[0]:
             return None
-        run_type_copy = self.validated_runs["TemplateData"][run_type].deepcopy()
+        run_type_copy = copy.deepcopy(self.validated_runs["TemplateData"][run_type])
         new_args = dict()
 
         for arg in run_type_copy["args"]:
@@ -176,7 +176,6 @@ class RunManager:
         :param action: str
         :return: dict
         """
-        print("TAG TO FIND: {}".format(tag_to_find))
         if self.initialized():
             if isinstance(tag_to_find, str):
                 for idx, run in enumerate(self.validated_runs["RunList"]):
@@ -184,8 +183,6 @@ class RunManager:
                         if action == "del":
                             run_copy = copy.deepcopy(run)
                             del self.validated_runs["RunList"][idx]
-                            # del run
-                            # self.validated_runs["RunList"].remove(run)
                             return run_copy
                         return run
         return None

--- a/gui/run_manager.py
+++ b/gui/run_manager.py
@@ -2,6 +2,7 @@
 import json
 import uuid
 import os
+from pathlib import Path
 import sys
 # import modules defined at ../
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -11,20 +12,28 @@ from src.validate import *
 
 class RunManager:
     def __init__(self, config_file=None):
-        self.current_run = None
+        self.current_run, self.validated_runs = None, None
         self.template_fields = ["args", "annotations", "prop_options", "types", "translations"]
         self.test_file = "example_test.json"
         if config_file is None:
             self.RUN_CONFIG = os.path.dirname(os.path.abspath('../example_config.json')) + '/example_config.json'
         elif config_file is not None:
             self.RUN_CONFIG = config_file
-        try:
+
+        # if self.RUN_CONFIG
+
+        if Path(self.RUN_CONFIG).is_file():
+            print("Valid file!")
             with open(self.RUN_CONFIG) as file:
                 parsed = json.load(file)
                 self.validated_runs = validate(parsed)
-                print(self.validated_runs)
-        except IOError:
-            print("Error: {} does not exist.\nPlease supply a valid onfiguration file.".format(self.RUN_CONFIG))
+        elif not Path(self.RUN_CONFIG).is_file():
+            if Path(os.path.dirname(os.path.abspath('example_config.json')) + '/example_config.json').is_file():
+                self.RUN_CONFIG = os.path.dirname(os.path.abspath('example_config.json')) + '/example_config.json'
+                with open(self.RUN_CONFIG) as file:
+                    parsed = json.load(file)
+                    self.validated_runs = validate(parsed)
+
         if not self.initialized():
             print("Run configuration not loaded. Please supply a valid configuration file.")
 
@@ -118,7 +127,7 @@ class RunManager:
         Returns runs from run list.
         :return: list
         """
-        if self.initialized:
+        if self.initialized():
             return self.validated_runs["RunList"]
 
     def get_run_list_tags(self):
@@ -127,7 +136,7 @@ class RunManager:
         Returns the tags of all runs currently in the run list.
         :return: list
         """
-        if self.initialized:
+        if self.initialized():
             return [(lambda x: x["args"]["Tag"])(x) for x in self.get_run_list()]
 
     def set_current_run(self, new_run_tag):
@@ -146,7 +155,7 @@ class RunManager:
         Used to track which run user is currently editing in the MainWindow.
         :return: string
         """
-        if self.initialized:
+        if self.initialized():
             return self.current_run
 
     def get_run_from_list(self, tag_to_find):
@@ -156,7 +165,7 @@ class RunManager:
         :param tag_to_find: a string (run tag) to look for
         :return: dict
         """
-        if self.initialized:
+        if self.initialized():
             if isinstance(tag_to_find, str):
                 for run in self.get_run_list():
                     if tag_to_find in run["args"]["Tag"]:
@@ -167,7 +176,7 @@ class RunManager:
         Returns available template types (e.g. ["HBIR", "HBIR_RT", ...]
         :return: list
         """
-        if self.initialized:
+        if self.initialized():
             return [self.validated_runs["TemplateData"].keys()]
 
     def get_template_type_args(self, run_type):
@@ -177,7 +186,7 @@ class RunManager:
         :param run_type: dict or str
         :return: dict
         """
-        if self.initialized:
+        if self.initialized():
             if not run_type:
                 return None
             if isinstance(run_type, dict):

--- a/gui/run_manager.py
+++ b/gui/run_manager.py
@@ -185,6 +185,10 @@ class RunManager:
                         return run
         return None
 
+    #
+    # def reorder(self, from, to):
+    #     pass
+
     def get_template_types(self):
         """
         Returns available template types (e.g. ["HBIR", "HBIR_RT", ...]

--- a/gui/run_manager.py
+++ b/gui/run_manager.py
@@ -4,6 +4,7 @@ import uuid
 import os
 from pathlib import Path
 import sys
+import copy
 # import modules defined at ../
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append('../src/')  # @todo: avoid PYTHONPATH
@@ -69,14 +70,14 @@ class RunManager:
                 if key == "TemplateData":
                     self.validated_runs[key][data["RunType"]] = data
                 elif key == "RunList":
-                    self.validated_runs["RunList"].append(data)
+                    self.validated_runs[key].append(data)
                     return True
             except Exception:  # not a valid run
                 return None
 
     def create_run(self, run_type):
         """
-        # RunList section.
+       'example_test.json' # RunList section.
 
         Creates a run to insert into run_list. Values will be initialized to a default value.
         :param run_type: str
@@ -84,7 +85,7 @@ class RunManager:
         """
         if run_type not in self.get_template_types()[0]:
             return None
-        run_type_copy = self.validated_runs["TemplateData"][run_type].copy()
+        run_type_copy = self.validated_runs["TemplateData"][run_type].deepcopy()
         new_args = dict()
 
         for arg in run_type_copy["args"]:
@@ -109,7 +110,7 @@ class RunManager:
         """
         if self.initialized():
             run = self.get_run_from_list(from_tag)
-            run_copy = run.copy()
+            run_copy = copy.deepcopy(run)
             if run_copy is not None and isinstance(run_copy, dict) and "Tag" in run_copy["args"]:
                 run_copy["args"]["Tag"] = "{}-{}".format(run["args"]["Tag"], "(copy)")
                 if self.insert_into_config_list("RunList", run_copy):
@@ -175,15 +176,18 @@ class RunManager:
         :param action: str
         :return: dict
         """
+        print("TAG TO FIND: {}".format(tag_to_find))
         if self.initialized():
             if isinstance(tag_to_find, str):
-                for run in self.get_run_list():
+                for idx, run in enumerate(self.validated_runs["RunList"]):
                     if tag_to_find in run["args"]["Tag"]:
                         if action == "del":
-                            run_copy = run.copy()
-                            del run
+                            run_copy = copy.deepcopy(run)
+                            del self.validated_runs["RunList"][idx]
+                            # del run
+                            # self.validated_runs["RunList"].remove(run)
                             return run_copy
-                    return run
+                        return run
         return None
 
     def get_template_types(self):

--- a/gui/run_manager.py
+++ b/gui/run_manager.py
@@ -12,7 +12,7 @@ from src.validate import *
 class RunManager:
     def __init__(self, config_file=None):
         self.current_run = None
-        self.template_fields = ["args", "annotations", "default_props", "types", "translations"]
+        self.template_fields = ["args", "annotations", "prop_options", "types", "translations"]
         self.test_file = "example_test.json"
         if config_file is None:
             self.RUN_CONFIG = os.path.dirname(os.path.abspath('../example_config.json')) + '/example_config.json'


### PR DESCRIPTION
User can now:

- (right-click) -> duplicate the chosen run, 
- (right-click) -> delete the chosen run,
- (File -> Create New Run) -> create new run based on run types in the config file.

When the user saves, the new runs are written to the config file (currently it uses a test file in the `~/gui/` directory).

