### PR TITLE
(Refactor) Move JVM Options validation to validate module

### DIFF
--- a/src/validate.py
+++ b/src/validate.py
@@ -16,12 +16,13 @@ DefaultJavaRunOptions = {
 
 JvmRunOptions = Schema(Or(
     And(None, Use(lambda _: DefaultJavaRunOptions)), 
+    And(is_stringy, Use(lambda s: { "path": s, "options": [] })), 
+    And([is_stringy], Use(lambda ss: { "path": ss[0], "options": ss[1:] })),
     And(dict, {
         "path": is_stringy,
-        "options": [is_stringy],
-        }), 
-    And(is_stringy, Use(lambda s: { "path": s, "options": [] })), 
-    And([is_stringy], Use(lambda ss: { "path": ss[0], "options": ss[1:] }))))
+        Optional("options", default=[]): [is_stringy],
+        })))
+
 
 TemplateSchema = Schema({
     "args": [is_stringy],

--- a/src/validate.py
+++ b/src/validate.py
@@ -1,4 +1,4 @@
-from schema import Schema, And, Or, Optional
+from schema import Schema, And, Or, Optional, Use
 
 # used for python2 and python3 string types
 from six import text_type
@@ -7,11 +7,26 @@ from six import text_type
 def is_stringy(v):
     return type(v) is text_type
 
+ValidRunTypes = ["multi", "composite", "distributed"]
+
+DefaultJavaRunOptions = {
+        "path": "java",
+        "options": []
+        }
+
+JvmRunOptions = Schema(Or(
+    And(None, Use(lambda _: DefaultJavaRunOptions)), 
+    And(dict, {
+        "path": is_stringy,
+        "options": [is_stringy],
+        }), 
+    And(is_stringy, Use(lambda s: { "path": s, "options": [] })), 
+    And([is_stringy], Use(lambda ss: { "path": ss[0], "options": ss[1:] }))))
 
 TemplateSchema = Schema({
     "args": [is_stringy],
-    Optional("run_type", default="composite"): And(is_stringy, lambda rt: rt.lower() in ["multi", "composite", "distributed_ctrl_txl", "distributed_sut"]),
-    Optional("java", default="java"): is_stringy,
+    Optional("run_type", default="composite"): And(is_stringy, lambda rt: rt.lower() in ValidRunTypes),
+    Optional("java", default="java"): JvmRunOptions,
     Optional("jar", default="specjbb2015.jar"): is_stringy,
     Optional("prop_options"): {
         is_stringy: object,

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -3,7 +3,8 @@ import json
 import testfixtures
 import logging
 
-from src.benchmark_run import SpecJBBRun, InvalidRunConfigurationException, JvmRunOptions, SpecJBBComponentOptions, SpecJBBComponentTypes
+from src.validate import JvmRunOptions
+from src.benchmark_run import SpecJBBRun, InvalidRunConfigurationException, SpecJBBComponentOptions, SpecJBBComponentTypes
 
 
 class TestBenchmarkRun(unittest.TestCase):
@@ -79,69 +80,6 @@ class TestBenchmarkRun(unittest.TestCase):
                 # need to have some actual logging output
                 self.assertTrue(l.actual())
 
-
-class TestJvmRunOptions(unittest.TestCase):
-    def test_given_none_will_fill_defaults(self):
-        self.assertTrue(JvmRunOptions())
-
-    def test_given_str(self):
-        java_path = "java"
-        j = JvmRunOptions(java_path)
-
-        self.assertEqual(j.path, java_path)
-        self.assertEqual(j["path"], java_path)
-        self.assertEqual(j.options, [])
-        self.assertEqual(j["options"], [])
-
-    def test_given_list(self):
-        java_list = ["java", "-jar", "example_jar"]
-        j = JvmRunOptions(java_list)
-
-        self.assertEqual(j.path, java_list[0])
-        self.assertEqual(j["path"], java_list[0])
-        self.assertEqual(j.options, java_list[1:])
-        self.assertEqual(j["options"], java_list[1:])
-
-    def test_given_dict(self):
-        valid = {
-            "path": "java",
-            "options": ["-jar", "example_jar"],
-        }
-
-        j = JvmRunOptions(valid)
-
-        self.assertEqual(j.path, valid["path"])
-        self.assertEqual(j["path"], valid["path"])
-        self.assertEqual(j.options, valid["options"])
-        self.assertEqual(j["options"], valid["options"])
-
-    def test_with_dict_missing_options(self):
-        valid = {
-            "path": "java",
-        }
-
-        j = JvmRunOptions(valid)
-
-        self.assertEqual(j.path, valid["path"])
-        self.assertEqual(j["path"], valid["path"])
-        self.assertEqual(j.options, [])
-        self.assertEqual(j["options"], [])
-
-    def test_validates_dictionaries(self):
-        invalid_missing_path = {
-            "options": []
-        }
-
-        with self.assertRaises(Exception):
-            j = JvmRunOptions(invalid_missing_path)
-
-        invalid_types = {
-            "path": 2,
-            "options": {}
-        }
-
-        with self.assertRaises(Exception):
-            j = JvmRunOptions(invalid_types)
 
 
 class TestSpecJBBComponentOptions(unittest.TestCase):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -194,3 +194,57 @@ class TestJavaRunOptionsValidator(TestCase):
                 }
 
         self.assertEqual(JvmRunOptions.validate(valid), valid)
+
+    def test_given_none_will_fill_defaults(self):
+        self.assertTrue(JvmRunOptions.validate(None))
+
+    def test_given_str(self):
+        java_path = "java"
+        j = JvmRunOptions.validate(java_path)
+
+        self.assertEqual(j["path"], java_path)
+        self.assertEqual(j["options"], [])
+
+    def test_given_list(self):
+        java_list = ["java", "-jar", "example_jar"]
+        j = JvmRunOptions.validate(java_list)
+
+        self.assertEqual(j["path"], java_list[0])
+        self.assertEqual(j["options"], java_list[1:])
+
+    def test_given_dict(self):
+        valid = {
+            "path": "java",
+            "options": ["-jar", "example_jar"],
+        }
+
+        j = JvmRunOptions.validate(valid)
+
+        self.assertEqual(j["path"], valid["path"])
+        self.assertEqual(j["options"], valid["options"])
+
+    def test_with_dict_missing_options(self):
+        valid = {
+            "path": "java",
+        }
+
+        j = JvmRunOptions.validate(valid)
+
+        self.assertEqual(j["path"], valid["path"])
+        self.assertEqual(j["options"], [])
+
+    def test_validates_dictionaries(self):
+        invalid_missing_path = {
+            "options": []
+        }
+
+        with self.assertRaises(Exception):
+            JvmRunOptions.validate(invalid_missing_path)
+
+        invalid_types = {
+            "path": 2,
+            "options": {}
+        }
+
+        with self.assertRaises(Exception):
+            JvmRunOptions(invalid_types)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,7 +1,7 @@
 from schema import SchemaError
 from unittest import TestCase
 import json
-from src.validate import validate, TemplateSchema, JvmRunOptions
+from src.validate import validate, TemplateSchema, JvmRunOptions, DefaultJavaRunOptions
 
 
 class TestSpectateConfigValidator(TestCase):
@@ -177,10 +177,7 @@ class TestSpectateConfigValidator(TestCase):
             })
 
     def test_java_options_validates_none(self):
-        self.assertEqual(JvmRunOptions.validate(None), {
-            "path": "java",
-            "options": [],
-            })
+        self.assertEqual(JvmRunOptions.validate(None), DefaultJavaRunOptions)
 
     def test_java_options_validates_list_of_strings(self):
         arglist = ["java", "arg1", "arg2"]

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -170,6 +170,7 @@ class TestSpectateConfigValidator(TestCase):
         self.assertEqual(v["RunList"][0]["times"], 1)
         self.assertEqual(v["RunList"][1]["times"], 2)
 
+class TestJavaRunOptionsValidator(TestCase):
     def test_java_options_validates_strings(self):
         self.assertEqual(JvmRunOptions.validate("echo"), {
             "path": "echo",

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,7 +1,7 @@
 from schema import SchemaError
 from unittest import TestCase
 import json
-from src.validate import validate, TemplateSchema
+from src.validate import validate, TemplateSchema, JvmRunOptions
 
 
 class TestSpectateConfigValidator(TestCase):
@@ -169,3 +169,30 @@ class TestSpectateConfigValidator(TestCase):
 
         self.assertEqual(v["RunList"][0]["times"], 1)
         self.assertEqual(v["RunList"][1]["times"], 2)
+
+    def test_java_options_validates_strings(self):
+        self.assertEqual(JvmRunOptions.validate("echo"), {
+            "path": "echo",
+            "options": [],
+            })
+
+    def test_java_options_validates_none(self):
+        self.assertEqual(JvmRunOptions.validate(None), {
+            "path": "java",
+            "options": [],
+            })
+
+    def test_java_options_validates_list_of_strings(self):
+        arglist = ["java", "arg1", "arg2"]
+        self.assertEqual(JvmRunOptions.validate(arglist), {
+            "path": arglist[0],
+            "options": arglist[1:],
+            })
+
+    def test_java_options_validates_dict_with_exact_keys(self):
+        valid = {
+                "path": "java",
+                "options": ["arg1", "arg2"],
+                }
+
+        self.assertEqual(JvmRunOptions.validate(valid), valid)


### PR DESCRIPTION
This moves a helper class in SpecJBBRun that handled validating java options to the `validate.py` module. Tests have been updated to reflect the new changes.