### PR TITLE
Define run IDs for individual runs (or not)

### DIFF
--- a/src/benchmark_run.py
+++ b/src/benchmark_run.py
@@ -10,6 +10,7 @@ import logging
 import configparser
 
 from src.task_runner import TaskRunner
+from src.validate import random_run_id
 
 log = logging.getLogger(__name__)
 
@@ -187,6 +188,7 @@ class SpecJBBRun:
                  injectors=None,
                  java=None,
                  jar=None,
+                 tag=None,
                  times=1,
                  props={},
                  props_file='specjbb2015.props'):
@@ -209,7 +211,7 @@ class SpecJBBRun:
         self.times = times
         self.props = props
         self.props_file = props_file
-        self.run_id = uuid4().hex
+        self.run_id = tag if tag else random_run_id()
         self.log = logging.LoggerAdapter(log, {'run_id': self.run_id})
 
         self.java = JvmRunOptions(java)

--- a/src/run_generator.py
+++ b/src/run_generator.py
@@ -39,6 +39,7 @@ class RunGenerator:
                 'injectors': injectors,
                 'java': template["java"],
                 'jar': template["jar"],
+                'tag': run["tag"],
                 'times': run["times"],
                 'props': props,
                 'props_file': template.get("props_file", 'specjbb2015.props'),

--- a/src/run_generator.py
+++ b/src/run_generator.py
@@ -1,4 +1,4 @@
-from src.validate import TemplateSchema, RunConfigSchema
+from src.validate import TemplateSchema, RunConfigSchema, random_run_id
 
 
 class RunGenerator:
@@ -39,7 +39,7 @@ class RunGenerator:
                 'injectors': injectors,
                 'java': template["java"],
                 'jar': template["jar"],
-                'tag': run["tag"],
+                'tag': run["tag"] if "tag" in run else random_run_id(),
                 'times': run["times"],
                 'props': props,
                 'props_file': template.get("props_file", 'specjbb2015.props'),

--- a/src/validate.py
+++ b/src/validate.py
@@ -1,3 +1,4 @@
+import uuid
 from schema import Schema, And, Or, Optional
 
 # used for python2 and python3 string types
@@ -7,6 +8,12 @@ from six import text_type
 def is_stringy(v):
     return type(v) is text_type
 
+def random_run_id():
+    """
+    Returns a value that will be a default, non-repeated
+    run ID used for a RunConfiguration object.
+    """
+    return uuid.uuid4().hex
 
 TemplateSchema = Schema({
     "args": [is_stringy],
@@ -36,6 +43,7 @@ RunConfigSchema = Schema({
         Optional(is_stringy): is_stringy,
     },
     Optional("times", default=1): int,
+    Optional("tag"): is_stringy,
 })
 
 SpectateConfig = Schema({
@@ -48,6 +56,18 @@ SpectateConfig = Schema({
 
 def validate(unvalidated):
     d = SpectateConfig.validate(unvalidated)
+
+    # each run needs a unique run id
+    custom_run_ids = list(map(lambda run: run["tag"], 
+        filter(lambda run: "tag" in run, d["RunList"])))
+
+    if custom_run_ids and len(set(custom_run_ids)) != len(custom_run_ids):
+        duplicates = [_id for _id in custom_run_ids if custom_run_ids.count(_id) > 1 ]
+        raise Exception("Duplicate custom run IDs provided to different configured runs: {}".format(duplicates))
+
+    # generate IDs for each unspecified run
+    for run in list(filter(lambda run: "tag" not in run, d["RunList"])):
+        run["tag"] = random_run_id()
 
     # each of the args that appear in the RunList,
     for run in d["RunList"]:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,7 +1,7 @@
 from schema import SchemaError
 from unittest import TestCase
 import json
-from src.validate import validate, TemplateSchema
+from src.validate import validate, TemplateSchema, random_run_id
 
 
 class TestSpectateConfigValidator(TestCase):
@@ -106,66 +106,125 @@ class TestSpectateConfigValidator(TestCase):
                 "RunList": []
             })
 
-    def test_RunList_with_times_validates(self):
-        sample_args = {
-            "Tag": "sample Tag",
-            "Kit Version": "kitVer",
-            "JDK": "jdk1.9",
-            "RTSTART": 2,
-            "JVM Options": "",
-            "NUMA Nodes": 4,
-            "Data Collection": "",
-            "T1": 1,
-            "T2": 2,
-            "T3": 3,
-        }
+    sample_hbir_template = {
+                "args": [
+                    "Tag", "Kit Version", "JDK", "RTSTART",
+                    "JVM Options", "NUMA Nodes", "Data Collection",
+                    "T1", "T2", "T3"
+                ],
+                "prop_options": {
+                    "specjbb.controller.type": "HBIR",
+                    "specjbb.time.server": False,
+                    "specjbb.comm.connect.client.pool.size": 192,
+                    "specjbb.comm.connect.selector.runner.count": 4,
+                    "specjbb.comm.connect.timeouts.connect": 650000,
+                    "specjbb.comm.connect.timeouts.read": 650000,
+                    "specjbb.comm.connect.timeouts.write": 650000,
+                    "specjbb.comm.connect.worker.pool.max": 320,
+                    "specjbb.customerDriver.threads": 64,
+                    "specjbb.customerDriver.threads.saturate": 144,
+                    "specjbb.customerDriver.threads.probe": 96,
+                    "specjbb.mapreducer.pool.size": 27
+                },
+                "translations": {
+                    "RTSTART": "specjbb.controller.rtcurve.start",
+                    "T1": "specjbb.forkjoin.workers.Tier1",
+                    "T2": "specjbb.forkjoin.workers.Tier2",
+                    "T3": "specjbb.forkjoin.workers.Tier3",
+                    "NUMA Nodes": "specjbb.group.count"
+                }
+            }
 
+    sample_args = {
+        "Tag": "sample Tag",
+        "Kit Version": "kitVer",
+        "JDK": "jdk1.9",
+        "RTSTART": 2,
+        "JVM Options": "",
+        "NUMA Nodes": 4,
+        "Data Collection": "",
+        "T1": 1,
+        "T2": 2,
+        "T3": 3,
+    }
+
+
+    def test_RunList_with_times_validates(self):
         v = validate({
                 "TemplateData": {
-                    "HBIR": {
-                        "args": [
-                            "Tag", "Kit Version", "JDK", "RTSTART",
-                            "JVM Options", "NUMA Nodes", "Data Collection",
-                            "T1", "T2", "T3"
-                        ],
-                        "prop_options": {
-                            "specjbb.controller.type": "HBIR",
-                            "specjbb.time.server": False,
-                            "specjbb.comm.connect.client.pool.size": 192,
-                            "specjbb.comm.connect.selector.runner.count": 4,
-                            "specjbb.comm.connect.timeouts.connect": 650000,
-                            "specjbb.comm.connect.timeouts.read": 650000,
-                            "specjbb.comm.connect.timeouts.write": 650000,
-                            "specjbb.comm.connect.worker.pool.max": 320,
-                            "specjbb.customerDriver.threads": 64,
-                            "specjbb.customerDriver.threads.saturate": 144,
-                            "specjbb.customerDriver.threads.probe": 96,
-                            "specjbb.mapreducer.pool.size": 27
-                        },
-                        "translations": {
-                            "RTSTART": "specjbb.controller.rtcurve.start",
-                            "T1": "specjbb.forkjoin.workers.Tier1",
-                            "T2": "specjbb.forkjoin.workers.Tier2",
-                            "T3": "specjbb.forkjoin.workers.Tier3",
-                            "NUMA Nodes": "specjbb.group.count"
-                        }
-                    },
+                    "HBIR": self.sample_hbir_template,
                 },
                 "RunList": [
                     {
                         "template_type": "HBIR",
-                        "args": sample_args,
+                        "args": self.sample_args,
                     },
                     {
                         "template_type": "HBIR",
-                        "args": sample_args,
+                        "args": self.sample_args,
                         "times": 2,
                     },
                 ]
             })
 
         for run in v["RunList"]:
-            self.assertEqual(sample_args, run["args"])
+            self.assertEqual(self.sample_args, run["args"])
 
         self.assertEqual(v["RunList"][0]["times"], 1)
         self.assertEqual(v["RunList"][1]["times"], 2)
+
+    def test_runs_have_default_tags(self):
+        v = validate({
+            "TemplateData": {
+                "HBIR": self.sample_hbir_template,
+                },
+            "RunList": [
+                {
+                    "template_type": "HBIR",
+                    "args": self.sample_args,
+                    }
+                ]
+            })
+
+        self.assertTrue(v["RunList"][0]["tag"])
+
+    def test_runs_have_custom_tags(self):
+        custom_tag = random_run_id()
+
+        v = validate({
+            "TemplateData": {
+                "HBIR": self.sample_hbir_template,
+                },
+            "RunList": [
+                {
+                    "template_type": "HBIR",
+                    "args": self.sample_args,
+                    "tag": custom_tag,
+                    }
+                ]
+            })
+
+        self.assertEqual(v["RunList"][0]["tag"], custom_tag)
+
+    def test_runs_have_distinct_ids(self):
+        custom_tag = "I forgot to make these distinct"
+
+        with self.assertRaises(Exception):
+            self.assertFalse({
+                "TemplateData": {
+                    "HBIR": self.sample_hbir_template,
+                    },
+                "RunList": [
+                    {
+                        "template_type": "HBIR",
+                        "args": self.sample_args,
+                        "tag": custom_tag,
+                        },
+                    {
+                        "template_type": "HBIR",
+                        "args": self.sample_args,
+                        "tag": custom_tag,
+                        }
+                    ]
+                })
+


### PR DESCRIPTION
## Overview

It used to be that `SpecJBBRun` generated its own run ID per run configuration defined in a `RunList`. This PR allows that to be customized, as well as being incorporated into the lifecycle of a run from validation to actual execution.

Blocks #147 until merged.

### Changes

This PR adds "tag" as a key in the `RunConfiguration` (one of the elements in a `RunList`) schema.
 - Adds `tag` as an argument to `SpecJBBRun` which is used as the folder name and guaranteed unique run ID
 - Adds validation for `tag` via `validate.validate` on a tate config. Passing no additional `tags` gives a unique uuid 
 - `RunGenerator.runs` passes `tag` as a key