### PR TITLE
run['tag'] should be run['args']['Tag']

### DIFF
--- a/src/run_generator.py
+++ b/src/run_generator.py
@@ -39,7 +39,7 @@ class RunGenerator:
                 'injectors': injectors,
                 'java': template["java"],
                 'jar': template["jar"],
-                'tag': run["tag"] if "tag" in run else random_run_id(),
+                'tag': run["args"]["Tag"] if "Tag" in run["args"] else random_run_id(),
                 'times': run["times"],
                 'props': props,
                 'props_file': template.get("props_file", 'specjbb2015.props'),


### PR DESCRIPTION
Very tiny PR.

So your changes for using tag inside of `RunGenerator` weren't actually resolving the tags in each run. 

`run['tag']` should be `run['args']['Tag']`

Which will allow GUI to run an individual run based on the run's Tag key.