### PR TITLE
Remove do_run from blackbox days

### DIFF
--- a/mainCLI.py
+++ b/mainCLI.py
@@ -76,38 +76,6 @@ blackbox_artifacts = [
 ]
 
 
-def do_run(arguments):
-    """
-    Does a run using scripts/run.sh from the provided property template and configuration.
-    """
-    with open(arguments['<config>'], 'r') as f:
-        args = json.loads(f.read())
-    stringified = list(map(lambda arg: str(arg), to_list(args['specjbb'])))
-    workdir = args['specjbb'].get('workdir', 'scripts')
-    scripts_abspath = relative_to_main(workdir)
-    workdir_abspath = relative_to_main('scripts')
-
-    # if we don't already have the scripts available to us
-    # copy them into the new location
-    if workdir != 'scripts':
-        copy(scripts_abspath, workdir_abspath)
-
-    def cleanup():
-        # we need to cleanup the cwd or worktree for some reason
-        if workdir != 'scripts':
-            rmtree(workdir_abspath)
-        else:
-            for name in map(lambda name: os.path.join(scripts_abspath, name),
-                            blackbox_artifacts):
-                os.remove(name)
-
-    try:
-        if not call(['bash', 'run.sh'] + stringified, cwd=workdir_abspath):
-            cleanup()
-    except:
-        cleanup()
-
-
 def do_validate(arguments):
     """
     Validate a configuration based on the schema provided.


### PR DESCRIPTION
So that somehow stayed in `mainCLI.py`. This PR removes it again.

## Why is this important?
It's important not to repeat ourselves in source, so we can present it in a few weeks all prim and proper. Redefining functions shouldn't be our norm!