### PR TITLE
Add Dockerfile for SPECtate!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM kennethreitz/pipenv
+
+COPY . /app
+
+CMD python3 mainCLI.py

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ pipenv install
 ```
 
 
+#### Docker
+
+This project has a Docker file. You can build an image 
+yourself and run SPECtate with it:
+
+```shell
+# build the image
+docker build -t SPECtate:latest .
+# run SPECtate
+docker run SPECtate:latest --help
+# would display the help text like you ran it yourself
+# with python mainCLI.py --help
+```
+
+
 ## Example CLI Usage
 
 * Run an example configuration:


### PR DESCRIPTION
Based off of the pipenv docker image. Allows a user to:
```shell
docker build -t tate:latest .
docker run tate:latest
```
...and it'll run like you installed it yourself!

This opens up the option for users oriented to using docker to have auto-builds of SPECtate instead of having to deal with `pipenv` or anything else.